### PR TITLE
fix ballot claim test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+output.json

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -118,7 +118,7 @@ contract Registry {
         require(didStart == false, "TCR already started");
         require(didRagequit == true, "need to ragequit before starting TCR");
 
-        tcrContract.start(_token);
+        tcrContract.start(_token, msg.sender);
         didStart = true;
 
         emit TCRStart(address(tcrContract), name, symbol, decimals, bootstrapList);

--- a/contracts/TCR.sol
+++ b/contracts/TCR.sol
@@ -188,7 +188,7 @@ contract TCR {
     // Initialization
     // -------------------------------------------------------------------------
 
-    function start(address _token) public onlyOwner returns(bool) {
+    function start(address _token, address _msgSender) public onlyOwner returns(bool) {
         require(startDate == 0, "TCR already started");
 
         // launch TCR token
@@ -236,7 +236,7 @@ contract TCR {
         tallyQueue.push(bootstrapTally);
         pollQueue.push(bootstrapPoll);
 
-        ballotQueue[0].votesByVoter[owner] = bootstrapSubmission;
+        ballotQueue[0].votesByVoter[_msgSender] = bootstrapSubmission;
         startDate = now;
         currentBallotIndex = 1;
 

--- a/test/tcr.js
+++ b/test/tcr.js
@@ -259,6 +259,10 @@ contract('TCR', ([creator, alice, bob]) => {
     });
 
     it('process ballot', async () => {
+        await setupDaoMembership();
+        const shares = '1';
+        await initTcr(shares);
+
         const votingDurationSecs = await tcr.votingDurationSecs();
         await moveForwardSecs(votingDurationSecs.toNumber());
 


### PR DESCRIPTION
previously the bootstrap ballot submission in TCR.sol is assigned to the owner of the contract (Registry.sol). this can be set to the `msg.sender` of the `start` transaction (via Registry.sol), allowing for
the ballot to be claimed.